### PR TITLE
add `pint` as requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/IAMconsortium/pyam/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  - url: https://github.com/IAMconsortium/pyam/archive/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+  # GitHub does not include submodules in the release archives,
+  # so get the latest version of the units repository directly
+  - git_url: https://github.com/IAMconsortium/units
+    folder: units
+  
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - seaborn
     - six
     - requests
+    - pint
 
 test:
   imports:


### PR DESCRIPTION
Adding pint as a requirement in the recipe and loading the IAMconsortium/units repo directly in the recipe, because GitHub doesn't package it in the release archives.