### PR TITLE
Include python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,17 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.7.1, <3.11
+    - python >=3.7.1, <3.12
     - pip
     - setuptools-scm
   run:
-    - python >=3.7.1, <3.11
+    - python >=3.7.1, <3.12
     - iam-units >=2020.4.21
     - datapackage
     - numpy >=1.19.0, <1.24


### PR DESCRIPTION
Which was added in https://github.com/IAMconsortium/pyam/pull/745

currently on python 3.11, pyam 1.6.0 is installed.