### PR TITLE
Fix allowed Python versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,5 +70,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - gidden
     - danielhuppmann

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - poetry-dynamic-versioning
     - pip
   run:
-    - python >={{ python_min }},<3.13
+    - python >={{ python_min }},<3.14
     - iam-units >=2020.4.21
     - ixmp4 >=0.9.0
     - matplotlib-base >=3.6.0


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


After releasing message-ix 3.10.0, our "Install from conda-forge" CI broke. After debugging via https://github.com/iiasa/message_ix/pull/919, I discovered that this is due to the recipe here excluding Python 3.13, even though pyam-iamc is already compatible with it. I'm guessing the version bump was simply forgotten during the last release.

So this PR bumps the allowed Python versions.
It also removes @gidden from the list of maintainers since he left IIASA and probably won't maintain this repo actively any longer.
